### PR TITLE
fix: use built-in json generation from sqlc

### DIFF
--- a/src/parrot/internal/sqlc.gleam
+++ b/src/parrot/internal/sqlc.gleam
@@ -269,21 +269,15 @@ pub fn decode_sqlc(data: dynamic.Dynamic) {
 pub fn gen_sqlc_yaml(engine: cli.Engine, queries: List(String)) {
   let result = "
 version: \"2\"
-plugins:
-  - name: jsonb
-    wasm:
-      url: https://github.com/daniellionel01/sqlc-gen-json/releases/download/v1.0.0/sqlc-gen-json.wasm
-      sha256: ffbd8cfaecc971d8cdf145591eac28731ffb50b7348131868ce66cc0e3192b7e
 sql:
   - schema: schema.sql
     queries: [" <> string.join(queries, ", ") <> "]
     engine: " <> engine_to_sqlc_string(engine) <> "
-    codegen:
-      - out: .
-        plugin: jsonb
-        options:
-          indent: \"  \"
-          filename: queries.json
+    gen:
+      json:
+        out: .
+        indent: \"  \"
+        filename: queries.json
   "
 
   string.trim(result)


### PR DESCRIPTION
I wasn't able to get the jsonb plugin working, but found that the built-in json functionality in sqlc produced a valid JSON file (https://docs.sqlc.dev/en/stable/reference/config.html#json)

This PR removes the dependency on `sqlc-gen-json.wasm` and uses the sqlc JSON support instead.