### PR TITLE
fix: error messages getting lost

### DIFF
--- a/src/parrot/internal/db.gleam
+++ b/src/parrot/internal/db.gleam
@@ -68,7 +68,10 @@ pub fn fetch_schema_postgresql(db: String) -> Result(String, errors.ParrotError)
     in: ".",
     opt: [],
   )
-  |> result.replace_error(errors.PgdumpError)
+  |> result.map_error(fn(e) {
+    let #(_, err) = e
+    errors.PgdumpError(err)
+  })
 }
 
 pub fn fetch_schema_sqlite(db: String) -> Result(String, errors.ParrotError) {

--- a/src/parrot/internal/errors.gleam
+++ b/src/parrot/internal/errors.gleam
@@ -13,7 +13,7 @@ pub type ParrotError {
 
   NoQueriesFound
   MysqldumpError
-  PgdumpError
+  PgdumpError(String)
 
   CodegenError
 }
@@ -27,7 +27,7 @@ pub fn err_to_string(error: ParrotError) {
     SqlcDownloadError(e) -> "there was an error downloading sqlc: " <> e
     SqlcVersionError(e) -> "incompatible sqlc version found: " <> e
     SqlcGenerateError(e) -> "could not call `sqlc generate`:\n" <> e
-    PgdumpError -> "there was an error pg_dump"
+    PgdumpError(e) -> e
     NoQueriesFound -> "no queries were found to codegen"
     UnknownEngine(engine) -> "unknown engine: " <> engine
     CodegenError -> "there was an error during codegen"


### PR DESCRIPTION
Resolves #48 

This PR fixes a few issues with errors getting dropped, which makes it harder to debug when things go wrong. This includes:

- When there are errors with the sql queries
- When `pg_dump` throws an error, when postgres isn't running or `pg_dump` is missing

I've tested this on both an M2 MacBook and Fedora Workstation 42.

## Screenshots

| Before | After | Note |
|--------|--------|--------|
| <img width="634" height="196" alt="query-error-before" src="https://github.com/user-attachments/assets/2bf8f03a-9f28-4ab3-9572-404c0e40d24e" /> | <img width="1054" height="314" alt="query-error-after" src="https://github.com/user-attachments/assets/648c2022-df06-4ffe-a85a-df2f8f15207b" /> | Errors from `sql generate` on MacOS |
| <img width="982" height="225" alt="pg_dump-error-before" src="https://github.com/user-attachments/assets/73d9ed3b-788b-4609-90cb-4e77ad9847d7" /> | <img width="1594" height="288" alt="pg_dump-error-after" src="https://github.com/user-attachments/assets/e4ad41b8-3a45-4e47-be78-41127d9672eb" /> | Error with `pg_dump` on fedora | 