### PR TITLE
change relative URLs to absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you use PostgreSQL, you also need to have installed [pg_dump](https://www.pos
 You now have type safe access to your sql queries.
 
 You might want to write wrapper functions for the database client library of your choice. If you are using [lpil/pog](https://github.com/lpil/pog) or [lpil/sqlight](https://github.com/lpil/sqlight), you are in luck!
-You can find functions to copy & paste into your codebase here: [wrappers](./docs/wrappers.md)
+You can find functions to copy & paste into your codebase here: [wrappers](https://github.com/daniellionel01/parrot/blob/main/docs/wrappers.md)
 
 An example with [lpil/sqlight](https://github.com/lpil/sqlight):
 ```gleam
@@ -116,9 +116,9 @@ pub fn main() {
 ## Examples
 
 If you want to see how this library works in action, take a look at the integration tests:
-- PostgreSQL: [./integration/psql](./integration/psql)
-- MySQL: [./integration/mysql](./integration/mysql)
-- SQlite: [./integration/sqlite](./integration/sqlite)
+- PostgreSQL: [integration/psql](https://github.com/daniellionel01/parrot/blob/main/integration/psql)
+- MySQL: [integration/mysql](https://github.com/daniellionel01/parrot/blob/main/integration/mysql)
+- SQlite: [integration/sqlite](https://github.com/daniellionel01/parrot/blob/main/integration/sqlite)
 
 ## Development
 
@@ -127,8 +127,8 @@ If you want to see how this library works in action, take a look at the integrat
 ### Database
 
 There are scripts to spawn a MySQL or PostgreSQL docker container:
--  [MySQL Script](./bin/mysql.sh)
--  [PostgreSQL Script](./bin/psql.sh)
+-  [MySQL Script](https://github.com/daniellionel01/parrot/blob/main/bin/mysql.sh)
+-  [PostgreSQL Script](https://github.com/daniellionel01/parrot/blob/main/bin/psql.sh)
 
 For example:
 ```sh


### PR DESCRIPTION
This changes the relative URLs in the README to absolute URLs.
With the original URLs, it was not possible to access these directories and files from the package's page on Hexdocs.

IIRC, you would need to republish the docs after merging this pull request.