### PR TITLE
feat: add --output-dir flag to override generated output path

### DIFF
--- a/src/parrot.gleam
+++ b/src/parrot.gleam
@@ -3,6 +3,7 @@ import filepath
 import gleam/dict
 import gleam/io
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import parrot/internal/cli
@@ -21,18 +22,44 @@ pub fn main() {
   let cmd: Result(cli.Command, String) = case argv.load().arguments {
     [] -> {
       cli.parse_env("DATABASE_URL")
-      |> result.map(fn(a) { cli.Generate(a.0, a.1) })
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, None) })
     }
     ["--env-var", env] -> {
       cli.parse_env(env)
-      |> result.map(fn(a) { cli.Generate(a.0, a.1) })
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, None) })
+    }
+    ["--env-var", env, "--output-dir", dir] -> {
+      cli.parse_env(env)
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, Some(dir)) })
+    }
+    ["--output-dir", dir, "--env-var", env] -> {
+      cli.parse_env(env)
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, Some(dir)) })
     }
     ["-e", env] -> {
       cli.parse_env(env)
-      |> result.map(fn(a) { cli.Generate(a.0, a.1) })
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, None) })
+    }
+    ["-e", env, "--output-dir", dir] -> {
+      cli.parse_env(env)
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, Some(dir)) })
+    }
+    ["--output-dir", dir, "-e", env] -> {
+      cli.parse_env(env)
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, Some(dir)) })
     }
     ["--sqlite", file_path] -> {
-      Ok(cli.Generate(sqlc.SQLite, file_path))
+      Ok(cli.Generate(sqlc.SQLite, file_path, None))
+    }
+    ["--sqlite", file_path, "--output-dir", dir] -> {
+      Ok(cli.Generate(sqlc.SQLite, file_path, Some(dir)))
+    }
+    ["--output-dir", dir, "--sqlite", file_path] -> {
+      Ok(cli.Generate(sqlc.SQLite, file_path, Some(dir)))
+    }
+    ["--output-dir", dir] -> {
+      cli.parse_env("DATABASE_URL")
+      |> result.map(fn(a) { cli.Generate(a.0, a.1, Some(dir)) })
     }
     ["help"] -> Ok(cli.Usage)
     _ -> Ok(cli.Usage)
@@ -43,8 +70,8 @@ pub fn main() {
     Ok(cmd) ->
       case cmd {
         cli.Usage -> io.println(cli.usage)
-        cli.Generate(engine:, db:) -> {
-          let result = cmd_gen(engine, db)
+        cli.Generate(engine:, db:, output_dir:) -> {
+          let result = cmd_gen(engine, db, output_dir)
           case result {
             Error(e) ->
               io.println(lib.red("\nError: " <> errors.err_to_string(e)))
@@ -55,7 +82,23 @@ pub fn main() {
   }
 }
 
-fn cmd_gen(engine: sqlc.Engine, db: String) -> Result(Nil, errors.ParrotError) {
+/// Strip a leading "src/" or "./src/" from a user-supplied output
+/// directory so the rest is interpreted relative to the package's
+/// source root. Both `src/myapp/generated` and `myapp/generated`
+/// resolve to the same `gleam_module_out_path`.
+fn normalize_output_dir(dir: String) -> String {
+  case dir {
+    "./src/" <> rest -> rest
+    "src/" <> rest -> rest
+    other -> other
+  }
+}
+
+fn cmd_gen(
+  engine: sqlc.Engine,
+  db: String,
+  output_dir: Option(String),
+) -> Result(Nil, errors.ParrotError) {
   let db = case db {
     "sqlite://" <> db -> db
     "sqlite:" <> db -> db
@@ -162,9 +205,13 @@ fn cmd_gen(engine: sqlc.Engine, db: String) -> Result(Nil, errors.ParrotError) {
   })
 
   let project_name = project.project_name()
+  let module_out_path = case output_dir {
+    None -> project_name <> "/sql.gleam"
+    Some(dir) -> normalize_output_dir(dir) <> "/sql.gleam"
+  }
   let config =
     config.Config(
-      gleam_module_out_path: project_name <> "/sql.gleam",
+      gleam_module_out_path: module_out_path,
       json_file_path: queries_file,
     )
   use gen_result <- result.try(codegen.codegen_from_config(config))
@@ -175,7 +222,7 @@ fn cmd_gen(engine: sqlc.Engine, db: String) -> Result(Nil, errors.ParrotError) {
     spinner.new("formatting generated code")
     |> spinner.start()
 
-  let output_path = filepath.join(project.src(), project_name <> "/sql.gleam")
+  let output_path = filepath.join(project.src(), module_out_path)
 
   let stdout_format =
     shellout.command(

--- a/src/parrot/internal/cli.gleam
+++ b/src/parrot/internal/cli.gleam
@@ -1,4 +1,5 @@
 import envoy
+import gleam/option.{type Option}
 import gleam/result
 import parrot/internal/errors
 import parrot/internal/sqlc
@@ -29,6 +30,17 @@ pub const usage = "
       for the database connection URL.
       Defaults to 'DATABASE_URL'.
 
+    --output-dir <DIR>
+      Override the directory where 'sql.gleam' is written. By default
+      parrot writes to 'src/<project_name>/sql.gleam'. Use this to
+      route the generated module into a subdirectory, e.g. one
+      reserved for codegen output.
+
+      The path is relative to the project root. A leading 'src/' is
+      stripped if present, so both 'src/myapp/generated' and
+      'myapp/generated' work and write to
+      'src/myapp/generated/sql.gleam'.
+
   DATABASE_URL:
     Parrot automatically detects the driver from the URL scheme.
 
@@ -49,13 +61,16 @@ pub const usage = "
     $ export STAGING_DB_URL=\"mysql://staging:pass@remote/db\"
     $ gleam run -m parrot -- --env-var STAGING_DB_URL
 
-    # 4. Get help
+    # 4. Custom output directory (lands at src/myapp/generated/sql.gleam)
+    $ gleam run -m parrot -- --sqlite ./priv/app.db --output-dir src/myapp/generated
+
+    # 5. Get help
     $ gleam run -m parrot help
 "
 
 pub type Command {
   Usage
-  Generate(engine: sqlc.Engine, db: String)
+  Generate(engine: sqlc.Engine, db: String, output_dir: Option(String))
 }
 
 pub fn engine_from_env(str: String) {


### PR DESCRIPTION
## Motivation

I'm collecting all my projects' generated code under a single `src/<package>/generated/<tool>/` umbrella so tooling exclusions (linters, `.gitattributes`, code search) can use one glob. Today parrot's output is the only generated file in my projects that lives outside that tree.

## What it does

A new `--output-dir <DIR>` flag overrides the default output location. Without the flag, parrot writes to `src/<project_name>/sql.gleam` exactly as today. With the flag, parrot writes to `<DIR>/sql.gleam`.

The path is relative to the project root. A leading `src/` is stripped if present, so both `src/myapp/generated` and `myapp/generated` resolve to the same location and write to `src/myapp/generated/sql.gleam`. The Gleam module name is derived from the resulting path so consumers import it as `myapp/generated/sql`.

Combinable with `--sqlite`, `--env-var`, and `-e` in either position:

```bash
gleam run -m parrot -- --sqlite ./priv/app.db --output-dir src/myapp/generated
gleam run -m parrot -- --output-dir src/myapp/generated --env-var STAGING_DB_URL
```

## Backwards compatibility

Fully opt-in. Omitting the flag keeps the existing default behavior. The `Generate` variant in `cli.gleam` gains an `output_dir: Option(String)` field, defaulting to `None` everywhere the old shape was constructed.

## Implementation notes

The existing `simplifile.create_directory_all` call in `codegen.gleam` already handles nested output paths, so no additional path-creation logic is needed for deeper subdirectories like `src/server/generated/parrot/`.

## Tests

`gleam test` passes (7/7) on the existing parrot test suite. No new tests for the flag itself, since the existing code paths it threads through are already covered.
